### PR TITLE
Update Syncthing-Android.yml

### DIFF
--- a/_data/projects/Syncthing-Android.yml
+++ b/_data/projects/Syncthing-Android.yml
@@ -10,7 +10,6 @@ tags:
 - android
 - sync
 - mobile
-- go
 upforgrabs:
   name: easy
   link: https://github.com/syncthing/syncthing-android/labels/easy


### PR DESCRIPTION
Removing `go` tag. The project might have changed direction, but there is no go code currently.